### PR TITLE
Fix elasticsearch buckets

### DIFF
--- a/bundles/EcommerceFrameworkBundle/IndexService/ProductList/ElasticSearch/AbstractElasticSearch.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/ProductList/ElasticSearch/AbstractElasticSearch.php
@@ -1268,7 +1268,7 @@ abstract class AbstractElasticSearch implements ProductListInterface
                 $data['key_as_string'] = $bucket['key_as_string'];
             } elseif (is_array($reverseAggregationBucket) && array_key_exists('doc_count', $reverseAggregationBucket)) { // reverse aggregation
                 $data['reverse_count'] = $reverseAggregationBucket['doc_count'];
-            } elseif (is_array($subAggregationBuckets) && array_key_exists('buckets', $subAggregationBuckets)) {         // sub aggregations
+            } elseif (is_array($subAggregationBuckets) && isset($subAggregationBuckets['buckets'])) {         // sub aggregations
                 foreach ($subAggregationBuckets['buckets'] as $bucket) {
                     $data[$subAggregationField][] = $this->convertBucketValues($bucket);
                 }

--- a/bundles/EcommerceFrameworkBundle/IndexService/ProductList/ElasticSearch/AbstractElasticSearch.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/ProductList/ElasticSearch/AbstractElasticSearch.php
@@ -1268,7 +1268,7 @@ abstract class AbstractElasticSearch implements ProductListInterface
                 $data['key_as_string'] = $bucket['key_as_string'];
             } elseif (is_array($reverseAggregationBucket) && array_key_exists('doc_count', $reverseAggregationBucket)) { // reverse aggregation
                 $data['reverse_count'] = $reverseAggregationBucket['doc_count'];
-            } elseif (is_array($subAggregationBuckets['buckets'])) {        // sub aggregations
+            } elseif (is_array($subAggregationBuckets) && array_key_exists('buckets', $subAggregationBuckets)) {         // sub aggregations
                 foreach ($subAggregationBuckets['buckets'] as $bucket) {
                     $data[$subAggregationField][] = $this->convertBucketValues($bucket);
                 }


### PR DESCRIPTION
## Changes in this pull request  
Resolves #

The convertBucketValues checks for subAggregationBuckets but it is not checking if we have at least an array and if the array key exists. This could lead to errors


