### PR TITLE
fix: remove system column "key" on filters

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/grid.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/grid.js
@@ -451,7 +451,7 @@ pimcore.object.helpers.grid = Class.create({
         var fields = this.fields;
         for (var i = 0; i < fields.length; i++) {
 
-            if(fields[i].key != "id" && fields[i].key != "published"
+            if(fields[i].key != "id" && fields[i].key != "published" && fields[i].key != "key"
                 && fields[i].key != "filename" && fields[i].key != "classname"
                 && fields[i].key != "creationDate" && fields[i].key != "modificationDate") {
 
@@ -498,7 +498,7 @@ pimcore.object.helpers.grid = Class.create({
             }
 
             if(fields[i].key != "id" && fields[i].key != "published" && fields[i].key != "fullpath"
-                && fields[i].key != "filename" && fields[i].key != "classname"
+                && fields[i].key != "filename" && fields[i].key != "classname" && fields[i].key != "key"
                 && fields[i].key != "creationDate" && fields[i].key != "modificationDate") {
 
                 var fieldType = fields[i].type;


### PR DESCRIPTION
## Changes in this pull request  
remove system column "key"  on grid filters as the other system columns in grid.js


### HOW
- open following object: https://demo.pimcore.com/admin/login/deeplink?object_81_object
- go to the Children Grid and add  "key" from the system column vai Grid Options
![grafik](https://user-images.githubusercontent.com/1992165/235602152-d9f5a0e4-6ccf-4e7b-873b-da4d12eb8722.png)
- open browsers developer toolbar and apply the changes
- note the console logs
![grafik](https://user-images.githubusercontent.com/1992165/235602589-4f8952eb-7bd7-4cb1-ae03-2f7568e2e7b7.png)


