### PR TITLE
fix: do array access fail save for php versions > 8.0

### DIFF
--- a/bundles/EcommerceFrameworkBundle/Model/DefaultMockup.php
+++ b/bundles/EcommerceFrameworkBundle/Model/DefaultMockup.php
@@ -73,7 +73,7 @@ class DefaultMockup implements ProductInterface, LinkGeneratorAwareInterface
      */
     public function getParam($key)
     {
-        return $this->params[$key];
+        return $this->params[$key] ?? null;
     }
 
     /**


### PR DESCRIPTION
Fix access on DefaultMockup params array fail save for php versions > 8.0