### PR TITLE
Fix objects tree sort method check

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tree.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tree.js
@@ -782,7 +782,7 @@ pimcore.object.tree = Class.create({
 
                     let currentSortMethod = record.data.sortBy;
 
-                    if (currentSortMethod !== "key" || user.admin || user.isAllowed("objects_sort_method")) {
+                    if (currentSortMethod === "key" || user.admin || user.isAllowed("objects_sort_method")) {
                         sortByItems.push({
                             text: t('by_key'),
                             iconCls: "pimcore_icon_alphabetical_sorting_az",
@@ -795,7 +795,7 @@ pimcore.object.tree = Class.create({
                         });
                     }
 
-                    if (currentSortMethod !== "index" || user.admin || user.isAllowed("objects_sort_method")) {
+                    if (currentSortMethod === "index" || user.admin || user.isAllowed("objects_sort_method")) {
                         sortByItems.push({
                             text: t('by_index'),
                             iconCls: "pimcore_icon_index_sorting",


### PR DESCRIPTION
## Changes in this pull request  
Changed check for sort menu in object tree to show the sort method.

I don't know what the original implentation should cover but in my understanding we have following initial position:

- There is a specific permission to disallow changing the data objects sort method BUT not the sorting itself
  ![grafik](https://github.com/pimcore/pimcore/assets/1992165/198201c4-65c1-429b-b17d-bcba00d06a7b)
- If we disallow the permission with the current implementation the user is still able to change the sort method because of the check in `tree.js`

With this change the user is not allowed to change the "sort method" but he is still allowed to change the sorting itself either by A-Z / Z-A or manually by changing the index via drag and drop.

To disallow the sorting itself, for me this a different topic and not covered with the permission `objects_sort_method`


### HOW

- prepare a folder with e.g. an admin user and set the sort method to A-Z
  ![grafik](https://github.com/pimcore/pimcore/assets/1992165/1fa59353-a904-4dac-aecb-c27005cc4593)
- create a User without the permission `objects_sort_method`
  ![grafik](https://github.com/pimcore/pimcore/assets/1992165/198201c4-65c1-429b-b17d-bcba00d06a7b)
- the user is still allowed to change the sort method
   ![grafik](https://github.com/pimcore/pimcore/assets/1992165/dbe120bf-f00b-47f0-b82c-05b131145168)


### CHANGE IN THIS PR

With this patch the user is still allowed to change the sorting but not the sort method
![grafik](https://github.com/pimcore/pimcore/assets/1992165/ce42ee16-7b32-4254-82cb-4e70dcd60d9b)




